### PR TITLE
docs: removing Continuous Integration (CI) badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Did I Break It
 [![crates.io](https://img.shields.io/crates/v/did_i_break_it)](https://crates.io/crates/did_i_break_it)
-[![Continuous Integration (CI)](https://github.com/DeveloperC286/did_i_break_it/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/DeveloperC286/did_i_break_it/actions/workflows/continuous-integration.yml)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 


### PR DESCRIPTION
As the badge is for the latest workflow not the main branch.

We will also not block a release on checks, so need to run the CI workflow on the main branch. The checks are performed as part of the pull request.